### PR TITLE
Parse option value into integer

### DIFF
--- a/src/components/ProtocolBuilder/Items/ItemBuilders/RadioBuilder.vue
+++ b/src/components/ProtocolBuilder/Items/ItemBuilders/RadioBuilder.vue
@@ -522,7 +522,11 @@ export default {
         'enableNegativeTokens': this.enableNegativeTokens,
         'isMultipleChoice': this.isMultipleChoice,
         'isSkippableItem': this.isSkippable,
-        'options': this.options,
+        'options': this.options.map(option => ({
+          ...option,
+          value: Number(option.value),
+          score: Number(option.score),
+        })),
       };
       this.$emit('updateOptions', responseOptions);
     },


### PR DESCRIPTION
# Resolves https://github.com/ChildMindInstitute/mindlogger-app/issues/1539, https://github.com/ChildMindInstitute/mindlogger-admin/issues/825
option.value and option.score should be integers.