### PR TITLE
Disable subscales and t-score for activity parts

### DIFF
--- a/src/components/ProtocolBuilder/Builder.vue
+++ b/src/components/ProtocolBuilder/Builder.vue
@@ -236,6 +236,11 @@ export default {
             return itemData;
           });
 
+          if (activityItems.length < activityInfo.orderList.length) {
+            delete activityInfo.finalSubScale
+            delete activityInfo.subScales
+          }
+
           const activityBuilderData = activityModel.getActivityBuilderData({
             ...activityInfo,
             items: activityItems,


### PR DESCRIPTION
# Resolves [#107](https://app.zenhub.com/workspaces/mindlogger-webapp-5e11094d0c26311588da9626/issues/childmindinstitute/mindlogger-applet-library/107)