### PR TITLE
feat: applet theme - reskinning

### DIFF
--- a/src/components/ProtocolBuilder/Builder.vue
+++ b/src/components/ProtocolBuilder/Builder.vue
@@ -108,6 +108,7 @@ export default {
       'activities',
       'prizeActivity',
       'templateUpdateRequest',
+      'themeId'
     ]),
     config() {
       return config;
@@ -135,7 +136,7 @@ export default {
   },
   async beforeMount() {
     this.setTemplates(this.templates);
-    this.setThemes(this.themes);
+    this.initThemes(this.themes);
     this.setVersions(this.versions);
     this.setCurrentScreen(config.PROTOCOL_SCREEN);
     this.setCurrentActivity(-1);
@@ -176,7 +177,7 @@ export default {
     ...mapMutations(config.MODULE_NAME, [
       'initProtocolData',
       'setTemplates',
-      'setThemes',
+      'initThemes',
       'setCurrentScreen',
       'setFormattedOriginalProtocol',
       'setPrizeActivity',
@@ -277,11 +278,17 @@ export default {
     },
 
     uploadProtocol (data) {
-      this.$emit("uploadProtocol", data);
+      this.$emit("uploadProtocol", {
+        applet: data,
+        themeId: this.themeId
+      });
     },
 
     updateProtocol (data) {
-      this.$emit("updateProtocol", data);
+      this.$emit("updateProtocol", {
+        protocol: data,
+        themeId: this.themeId
+      });
     },
 
     onUploadError (msg) {

--- a/src/components/ProtocolBuilder/Builder.vue
+++ b/src/components/ProtocolBuilder/Builder.vue
@@ -136,7 +136,10 @@ export default {
   },
   async beforeMount() {
     this.setTemplates(this.templates);
+
     this.initThemes(this.themes);
+    this.initThemeId(this.initialData);
+
     this.setVersions(this.versions);
     this.setCurrentScreen(config.PROTOCOL_SCREEN);
     this.setCurrentActivity(-1);
@@ -178,6 +181,7 @@ export default {
       'initProtocolData',
       'setTemplates',
       'initThemes',
+      'initThemeId',
       'setCurrentScreen',
       'setFormattedOriginalProtocol',
       'setPrizeActivity',

--- a/src/components/ProtocolBuilder/Builder.vue
+++ b/src/components/ProtocolBuilder/Builder.vue
@@ -75,6 +75,11 @@ export default {
       required: false,
       default: null,
     },
+    themes: {
+      type: Array,
+      required: false,
+      default: null,
+    },
     versions: {
       type: Array,
       required: false,
@@ -130,6 +135,7 @@ export default {
   },
   async beforeMount() {
     this.setTemplates(this.templates);
+    this.setThemes(this.themes);
     this.setVersions(this.versions);
     this.setCurrentScreen(config.PROTOCOL_SCREEN);
     this.setCurrentActivity(-1);
@@ -170,6 +176,7 @@ export default {
     ...mapMutations(config.MODULE_NAME, [
       'initProtocolData',
       'setTemplates',
+      'setThemes',
       'setCurrentScreen',
       'setFormattedOriginalProtocol',
       'setPrizeActivity',

--- a/src/components/ProtocolBuilder/Builder.vue
+++ b/src/components/ProtocolBuilder/Builder.vue
@@ -282,17 +282,11 @@ export default {
     },
 
     uploadProtocol (data) {
-      this.$emit("uploadProtocol", {
-        applet: data,
-        themeId: this.themeId
-      });
+      this.$emit("uploadProtocol", data);
     },
 
     updateProtocol (data) {
-      this.$emit("updateProtocol", {
-        protocol: data,
-        themeId: this.themeId
-      });
+      this.$emit("updateProtocol", data);
     },
 
     onUploadError (msg) {

--- a/src/components/ProtocolBuilder/ProtocolBuilder.vue
+++ b/src/components/ProtocolBuilder/ProtocolBuilder.vue
@@ -50,6 +50,38 @@
             @onRemove="onRemoveImage()"
             @onNotify="onEventNotify($event)"
           />
+
+          <v-subheader class="ml-10">
+            Theme
+          </v-subheader>
+
+          <v-select
+              v-model="theme"
+              :items="themes"
+              :label="'Select theme'"
+              item-text="label"
+              item-value="value"
+              hide-details
+              single-line
+              outlined
+              dense
+          />
+
+          <v-menu>
+            <v-list>
+              <v-list-item>
+                <v-list-item-title>MindLogger</v-list-item-title>
+              </v-list-item>
+
+              <v-list-item>
+                <v-list-item-title>ETH Zürich</v-list-item-title>
+              </v-list-item>
+
+              <v-list-item>
+                <v-list-item-title>CRI</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
         </div>
       </v-card>
 
@@ -121,8 +153,8 @@
       </v-card>
     </v-form>
 
-    <LandingPageEditor 
-      :visibility="markdownDialog" 
+    <LandingPageEditor
+      :visibility="markdownDialog"
       :markdownText="markdownData"
       @close="onCloseEditor"
       @submit="onSubmitEditor"
@@ -146,7 +178,7 @@
 
 <script>
 import LandingPageEditor from './LandingPageEditor';
-import Uploader from './Uploader.vue'; 
+import Uploader from './Uploader.vue';
 import Protocol from '../../models/Protocol';
 import Activity from '../../models/Protocol';
 import Item from '../../models/Protocol';
@@ -162,7 +194,7 @@ export default {
   data () {
     return {
       markdownDialog: false,
-      textRules: [(v) => !!v || "This field is required"],
+      textRules: [(v) => !!v || "This field is required"]
     }
   },
   computed: {
@@ -194,6 +226,31 @@ export default {
         this.updateProtocolMetaInfo({ markdownData })
       }
     },
+    theme: {
+      get: function () {
+        return this.protocol.theme
+      },
+      set: function (theme) {
+        this.updateProtocolMetaInfo({ theme })
+      }
+    },
+    themes() {
+      // TODO: load list from API
+      return [
+        {
+          label: 'MindLogger',
+          value: "mindlogger",
+        },
+        {
+          label: 'ETH Zürich',
+          value: "eth",
+        },
+        {
+          label: 'CRI',
+          value: "cri",
+        }
+      ]
+    },
 
     appletImage: {
       get: function () {
@@ -210,8 +267,8 @@ export default {
 
     activityStatus () {
       return this.withoutPrize.map(activity => !(
-        !activity.valid 
-          || activity.items.some(item => !item.valid) 
+        !activity.valid
+          || activity.items.some(item => !item.valid)
           || activity.items.length === 0
           || activity.subScales.some(subScale => !subScale.valid)
           || activity.conditionalItems.some(conditional => !conditional.valid)
@@ -219,13 +276,13 @@ export default {
     },
   },
   methods: {
-    ...mapMutations(config.MODULE_NAME, 
+    ...mapMutations(config.MODULE_NAME,
       [
-        'updateProtocolMetaInfo', 
-        'duplicateActivity', 
-        'deleteActivity', 
-        'addActivity', 
-        'setCurrentActivity', 
+        'updateProtocolMetaInfo',
+        'duplicateActivity',
+        'deleteActivity',
+        'addActivity',
+        'setCurrentActivity',
         'setCurrentScreen',
       ]
     ),
@@ -238,7 +295,7 @@ export default {
       });
     },
     async onAddImageFromDevice (uploadFunction) {
-      this.$emit('loading', true); 
+      this.$emit('loading', true);
 
       try {
         this.appletImage = await uploadFunction();
@@ -266,7 +323,7 @@ export default {
       });
     },
     onEventNotify (event) {
-      this.$emit('loading', false); 
+      this.$emit('loading', false);
       this.$emit('notify', event);
     },
     onSubmitEditor (markdownData) {
@@ -290,7 +347,7 @@ export default {
 
       this.addActivity();
       this.editActivity(activityCount);
-    },
+    }
   }
 }
 </script>

--- a/src/components/ProtocolBuilder/ProtocolBuilder.vue
+++ b/src/components/ProtocolBuilder/ProtocolBuilder.vue
@@ -51,11 +51,11 @@
             @onNotify="onEventNotify($event)"
           />
 
-          <v-subheader class="ml-10">
+          <v-subheader class="ml-10" v-if="themes">
             Theme
           </v-subheader>
 
-          <v-select
+          <v-select v-if="themes"
               v-model="theme"
               :items="themes"
               :label="'Select theme'"
@@ -66,22 +66,6 @@
               outlined
               dense
           />
-
-          <v-menu>
-            <v-list>
-              <v-list-item>
-                <v-list-item-title>MindLogger</v-list-item-title>
-              </v-list-item>
-
-              <v-list-item>
-                <v-list-item-title>ETH Zürich</v-list-item-title>
-              </v-list-item>
-
-              <v-list-item>
-                <v-list-item-title>CRI</v-list-item-title>
-              </v-list-item>
-            </v-list>
-          </v-menu>
         </div>
       </v-card>
 
@@ -198,7 +182,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(config.MODULE_NAME, ['protocol', 'activities']),
+    ...mapGetters(config.MODULE_NAME, ['protocol', 'activities', 'themes']),
     config() {
       return config;
     },
@@ -233,23 +217,6 @@ export default {
       set: function (theme) {
         this.updateProtocolMetaInfo({ theme })
       }
-    },
-    themes() {
-      // TODO: load list from API
-      return [
-        {
-          label: 'MindLogger',
-          value: "mindlogger",
-        },
-        {
-          label: 'ETH Zürich',
-          value: "eth",
-        },
-        {
-          label: 'CRI',
-          value: "cri",
-        }
-      ]
     },
 
     appletImage: {

--- a/src/components/ProtocolBuilder/ProtocolBuilder.vue
+++ b/src/components/ProtocolBuilder/ProtocolBuilder.vue
@@ -56,7 +56,7 @@
           </v-subheader>
 
           <v-select v-if="themes && themes.length"
-              v-model="theme"
+              v-model="selectedTheme"
               :items="themes"
               :label="'Select theme'"
               item-text="name"
@@ -219,7 +219,7 @@ export default {
       }
     },
 
-    theme: {
+    selectedTheme: {
       get: function () {
         return this.themeId
       },

--- a/src/components/ProtocolBuilder/ProtocolBuilder.vue
+++ b/src/components/ProtocolBuilder/ProtocolBuilder.vue
@@ -60,7 +60,7 @@
               :items="themes"
               :label="'Select theme'"
               item-text="name"
-              item-value="themeId"
+              item-value="_id"
               hide-details
               single-line
               outlined

--- a/src/components/ProtocolBuilder/ProtocolBuilder.vue
+++ b/src/components/ProtocolBuilder/ProtocolBuilder.vue
@@ -51,16 +51,16 @@
             @onNotify="onEventNotify($event)"
           />
 
-          <v-subheader class="ml-10" v-if="themes">
+          <v-subheader class="ml-10" v-if="themes && themes.length">
             Theme
           </v-subheader>
 
-          <v-select v-if="themes"
+          <v-select v-if="themes && themes.length"
               v-model="theme"
               :items="themes"
               :label="'Select theme'"
-              item-text="label"
-              item-value="value"
+              item-text="name"
+              item-value="themeId"
               hide-details
               single-line
               outlined
@@ -182,7 +182,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(config.MODULE_NAME, ['protocol', 'activities', 'themes']),
+    ...mapGetters(config.MODULE_NAME, ['protocol', 'activities', 'themes', 'themeId']),
     config() {
       return config;
     },
@@ -210,21 +210,21 @@ export default {
         this.updateProtocolMetaInfo({ markdownData })
       }
     },
-    theme: {
-      get: function () {
-        return this.protocol.theme
-      },
-      set: function (theme) {
-        this.updateProtocolMetaInfo({ theme })
-      }
-    },
-
     appletImage: {
       get: function () {
         return this.protocol.image
       },
       set: function (appletImage) {
         this.updateProtocolMetaInfo({ image: appletImage })
+      }
+    },
+
+    theme: {
+      get: function () {
+        return this.themeId
+      },
+      set: function (themeId) {
+        this.updateThemeId(themeId)
       }
     },
 
@@ -251,6 +251,7 @@ export default {
         'addActivity',
         'setCurrentActivity',
         'setCurrentScreen',
+        'updateThemeId'
       ]
     ),
     onAddImageFromUrl (event) {

--- a/src/header/header.vue
+++ b/src/header/header.vue
@@ -279,7 +279,9 @@ export default {
       'activities',
       'currentActivity',
       'formattedOriginalProtocol',
-      'versions'
+      'versions',
+      'themeId',
+      'originalThemeId'
     ]),
     itemStatus () {
       return this.currentActivity && this.currentActivity.items.every(item => item.valid);
@@ -314,8 +316,13 @@ export default {
 
       this.formattedProtocol().then((data) => {
         if (!this.formattedOriginalProtocol) {
-          this.$emit("uploadProtocol", data);
+          this.$emit("uploadProtocol", {
+            applet: data,
+            themeId: this.themeId
+          });
         } else {
+          const updateTheme = this.themeId !== undefined && (this.originalThemeId === undefined || this.originalThemeId !== this.themeId);
+
           let { upgrade, updates, removed } = Protocol.getChangeInfo(this.formattedOriginalProtocol, data, true);
           let newVersion = util.upgradeVersion(this.protocol.protocolVersion, upgrade);
 
@@ -326,7 +333,12 @@ export default {
             data.removed = removed;
             data.baseVersion = this.protocol.protocolVersion;
 
-            this.$emit("updateProtocol", data);
+            this.$emit("updateProtocol", {
+              protocol: data,
+              ...(updateTheme && {themeId: this.themeId})
+            });
+          } else if (updateTheme) {
+            this.$emit("updateProtocol", {themeId: this.themeId});
           } else {
             this.$emit("onUploadError", 'Please make changes to update applet');
           }

--- a/src/store/modules/appletBuilder/getters.js
+++ b/src/store/modules/appletBuilder/getters.js
@@ -44,6 +44,10 @@ export default {
     return state.templates;
   },
 
+  themes (state) {
+    return state.themes;
+  },
+
   currentScreen (state) {
     return state.currentScreen;
   },

--- a/src/store/modules/appletBuilder/getters.js
+++ b/src/store/modules/appletBuilder/getters.js
@@ -44,6 +44,10 @@ export default {
     return state.original;
   },
 
+  originalThemeId (state) {
+    return state.originalThemeId;
+  },
+
   itemTemplates (state) {
     return state.templates;
   },

--- a/src/store/modules/appletBuilder/getters.js
+++ b/src/store/modules/appletBuilder/getters.js
@@ -21,6 +21,10 @@ const activityGetters = {
 
   tokenPrizeModal (state) {
     return state.protocol.tokenPrizeModal;
+  },
+
+  themeId (state) {
+    return state.themeId;
   }
 };
 

--- a/src/store/modules/appletBuilder/mutations.js
+++ b/src/store/modules/appletBuilder/mutations.js
@@ -254,10 +254,12 @@ export default {
         return initialData.applet.themeId;
       }
 
-      return themes && themes.length >= 1 ? themes[0].themeId : null;
+      return themes && themes.length >= 1 ? themes[0]._id : null;
     }
 
-    state.themeId = initDefaultThemeId(state.themes, initialData);
+    const themeId = initDefaultThemeId(state.themes, initialData);
+    state.themeId = themeId;
+    state.originalThemeId = themeId;
   },
 
   setCurrentScreen (state, screen) {

--- a/src/store/modules/appletBuilder/mutations.js
+++ b/src/store/modules/appletBuilder/mutations.js
@@ -244,6 +244,10 @@ export default {
     state.templates = templates;
   },
 
+  setThemes (state, themes) {
+    state.themes = themes;
+  },
+
   setCurrentScreen (state, screen) {
     state.currentScreen = screen;
   },

--- a/src/store/modules/appletBuilder/mutations.js
+++ b/src/store/modules/appletBuilder/mutations.js
@@ -246,9 +246,18 @@ export default {
 
   initThemes (state, themes) {
     state.themes = themes;
+  },
 
-    const theme = themes ? themes.find(theme => theme.name === 'mindlogger') : null;
-    state.themeId = theme ? theme.themeId : null;
+  initThemeId (state, initialData) {
+    const initDefaultThemeId = (themes, initialData) => {
+      if (initialData && initialData.applet && initialData.applet.themeId) {
+        return initialData.applet.themeId;
+      }
+
+      return themes && themes.length >= 1 ? themes[0].id : null;
+    }
+
+    state.themeId = initDefaultThemeId(state.themes, initialData);
   },
 
   setCurrentScreen (state, screen) {

--- a/src/store/modules/appletBuilder/mutations.js
+++ b/src/store/modules/appletBuilder/mutations.js
@@ -244,8 +244,11 @@ export default {
     state.templates = templates;
   },
 
-  setThemes (state, themes) {
+  initThemes (state, themes) {
     state.themes = themes;
+
+    const theme = themes ? themes.find(theme => theme.name === 'mindlogger') : null;
+    state.themeId = theme ? theme.themeId : null;
   },
 
   setCurrentScreen (state, screen) {
@@ -256,6 +259,10 @@ export default {
   updateProtocolMetaInfo (state, obj) {
     Object.assign(state.protocol, obj);
     state.protocol.valid = Protocol.checkValidation(state.protocol);
+  },
+
+  updateThemeId (state, themeId) {
+      state.themeId = themeId;
   },
 
   resetProtocol (state) {

--- a/src/store/modules/appletBuilder/mutations.js
+++ b/src/store/modules/appletBuilder/mutations.js
@@ -254,7 +254,7 @@ export default {
         return initialData.applet.themeId;
       }
 
-      return themes && themes.length >= 1 ? themes[0].id : null;
+      return themes && themes.length >= 1 ? themes[0].themeId : null;
     }
 
     state.themeId = initDefaultThemeId(state.themes, initialData);

--- a/src/store/modules/appletBuilder/state.js
+++ b/src/store/modules/appletBuilder/state.js
@@ -8,6 +8,7 @@ export const getInitialProtocol = () => ({
   markdownData: '',
   image: '',
   name: '',
+  theme: 'mindlogger',
   protocolVersion: '1.0.0',
   valid: false,
   prizeActivity: null,

--- a/src/store/modules/appletBuilder/state.js
+++ b/src/store/modules/appletBuilder/state.js
@@ -8,7 +8,6 @@ export const getInitialProtocol = () => ({
   markdownData: '',
   image: '',
   name: '',
-  theme: 'mindlogger',
   protocolVersion: '1.0.0',
   valid: false,
   prizeActivity: null,
@@ -101,4 +100,5 @@ export default {
   original: null,
   currentScreen: config.PROTOCOL_SCREEN,
   currentActivity: null,
+  themeId: null,
 }

--- a/src/store/modules/appletBuilder/state.js
+++ b/src/store/modules/appletBuilder/state.js
@@ -101,4 +101,5 @@ export default {
   currentScreen: config.PROTOCOL_SCREEN,
   currentActivity: null,
   themeId: null,
+  originalThemeId: null
 }


### PR DESCRIPTION
### Feature Description

Gives the ability to select and edit themes upon creating or modifying an applet in the administration console.

### Backend

The related backend PR which adds the new endpoints is [#1101](https://github.com/ChildMindInstitute/mindlogger-backend/pull/1101).

### Credits

This pull request is part of the "Citizen Science Logger" project and, provided by the [ETH Library Lab](https://www.librarylab.ethz.ch/).